### PR TITLE
fix: migrations assume flarum is already installed

### DIFF
--- a/migrations/2019_09_15_000000_migrate_extension_settings.php
+++ b/migrations/2019_09_15_000000_migrate_extension_settings.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Database\Schema\Builder;
 
 return [

--- a/migrations/2019_09_15_000000_migrate_extension_settings.php
+++ b/migrations/2019_09_15_000000_migrate_extension_settings.php
@@ -14,17 +14,13 @@ use Illuminate\Database\Schema\Builder;
 
 return [
     'up' => function (Builder $schema) {
-        /**
-         * @var SettingsRepositoryInterface
-         */
-        $settings = resolve('flarum.settings');
+        $db = $schema->getConnection();
         $keys = ['username', 'email', 'ip', 'frequency', 'api_key'];
 
         foreach ($keys as $key) {
-            if (($value = $settings->get($full = "sfs.$key")) != null) {
-                $settings->set("fof-stopforumspam.$key", $value);
-                $settings->delete($full);
-            }
+            $db->table('settings')
+                ->where('key', "sfs.$key")
+                ->update(['key' => "fof-stopforumspam.$key"]);
         }
     },
     'down' => function (Builder $schema) {


### PR DESCRIPTION
Relates to https://github.com/flarum/framework/pull/3655

**Changes proposed in this pull request:**
Use Schema DB connection instead of resolving `flarum.settings`. 
More info @ https://github.com/FriendsOfFlarum/reactions/pull/55.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `composer test`).
